### PR TITLE
Fix gstreamer-send for Firefox temporarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Simonacca Fotokite](https://github.com/simonacca-fotokite)
 * [Steve Denman](https://github.com/stevedenman)
 * [RunningMan](https://github.com/xsbchen)
+* [mchlrhw](https://github.com/mchlrhw)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/gstreamer-send/jsfiddle/demo.js
+++ b/gstreamer-send/jsfiddle/demo.js
@@ -28,9 +28,9 @@ pc.onicecandidate = event => {
 }
 
 // Offer to receive 1 audio, and 2 video tracks
-pc.addTransceiver('audio', {'direction': 'recvonly'})
-pc.addTransceiver('video', {'direction': 'recvonly'})
-pc.addTransceiver('video', {'direction': 'recvonly'})
+pc.addTransceiver('audio', {'direction': 'sendrecv'})
+pc.addTransceiver('video', {'direction': 'sendrecv'})
+pc.addTransceiver('video', {'direction': 'sendrecv'})
 pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
 
 window.startSession = () => {


### PR DESCRIPTION
#### Description
Firefox expects answering SDP to comply with [RFC3246](https://www.packetizer.com/rfc/rfc3264/), specifically that "If a media stream is listed as recvonly in the offer, the answer MUST be marked as sendonly or inactive in the answer." from section 6.1.

Chrome seems to be more lenient, but the gstreamer-send example application fails in Firefox with `InvalidSessionDescriptionError: Answer tried to set recv when offer did not set send`.

This PR fixes the example for Firefox by changing the browser transceivers to `sendrecv`, even though they never send any media.

This is a temporary fix until the transceiver matching behaviour is fixed in Pion.
