### PR TITLE
Modified so this program works with Safari and recent Firefox

### DIFF
--- a/gstreamer-send/main.go
+++ b/gstreamer-send/main.go
@@ -26,10 +26,6 @@ func main() {
 	// We make our own mediaEngine and place the sender's codecs in it so that we use the
 	// dynamic media type from the sender in our answer.
 	mediaEngine := webrtc.MediaEngine{}
-
-	// Add codecs to the mediaEngine. Note that even though we are only going to echo back the sender's video we also
-	// add audio codecs. This is because createAnswer will create an audioTransceiver and associated SDP and we currently
-	// cannot tell it not to. The audio SDP must match the sender's codecs too...
 	err := mediaEngine.PopulateFromSDP(offer)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
#### Description

The program would not work on Safari or recent versions of Firefox because it
assumed a mapping of VP8 to dynamic payload type.

This change uses the dynamic payload types from the offer's SDP when making the
sending tracks.  Still sends VP8 (instead of the browser's preferred
codec) to avoid having to coordinate codec parameters between browser
and gstreamer.

#### Dependency

Uses code that is part of the following pull request:

https://github.com/pion/webrtc/pull/764