### PR TITLE
Bugfix/janus semantics

### DIFF
--- a/janus-gateway/streaming/main.go
+++ b/janus-gateway/streaming/main.go
@@ -60,6 +60,7 @@ func main() {
 				URLs: []string{"stun:stun.l.google.com:19302"},
 			},
 		},
+		SDPSemantics: webrtc.SDPSemanticsUnifiedPlanWithFallback,
 	}
 
 	// Create a new RTCPeerConnection

--- a/janus-gateway/video-room/main.go
+++ b/janus-gateway/video-room/main.go
@@ -43,6 +43,7 @@ func main() {
 				URLs: []string{"stun:stun.l.google.com:19302"},
 			},
 		},
+		SDPSemantics: webrtc.SDPSemanticsUnifiedPlanWithFallback,
 	}
 
 	// Create a new RTCPeerConnection


### PR DESCRIPTION
#### Description
Explicitly use unified plan with fallback for janus demos
#### Reference issue
Fixes "panic: TypeError: offer SDP semantics does not match configuration"
