### PR TITLE
Fix janus streaming example: keepalive was not firing

### DIFF
--- a/janus-gateway/streaming/main.go
+++ b/janus-gateway/streaming/main.go
@@ -71,6 +71,16 @@ func main() {
 		panic(err)
 	}
 
+	go func() {
+		for {
+			if _, keepAliveErr := session.KeepAlive(); err != nil {
+				panic(keepAliveErr)
+			}
+
+			time.Sleep(5 * time.Second)
+		}
+	}()
+
 	go watchHandle(handle)
 
 	// Get streaming list
@@ -170,13 +180,5 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-	}
-	for {
-		_, err = session.KeepAlive()
-		if err != nil {
-			panic(err)
-		}
-
-		time.Sleep(5 * time.Second)
 	}
 }


### PR DESCRIPTION
This would lead to timeout failures with:
"Connection State has changed disconnected
 Connection State has changed failed"

#### Description
This is similar to what the videoroom is already doing.
