### PR TITLE
Use sample builder data for webm audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [EricSong](https://github.com/xsephiroth) - *Implement GstV4l2Alsa example*
 * [Tristan Matthews](https://github.com/tmatth)
 * [Alexey Kravtsov](https://github.com/alexey-kravtsov) - *GStreamer encoder tune*
+* [Tarrence van As](https://github.com/tarrencev) - *Webm saver fix*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/save-to-webm/main.go
+++ b/save-to-webm/main.go
@@ -68,7 +68,7 @@ func (s *webmSaver) PushOpus(rtpPacket *rtp.Packet) {
 		if s.audioWriter != nil {
 			s.audioTimestamp += sample.Samples
 			t := s.audioTimestamp / 48
-			if _, err := s.audioWriter.Write(true, int64(t), rtpPacket.Payload); err != nil {
+			if _, err := s.audioWriter.Write(true, int64(t), sample.Data); err != nil {
 				panic(err)
 			}
 		}


### PR DESCRIPTION
Previously it was using the raw rtp payload. I think this might be a subtle bug?