### PR TITLE
Add snapshot example

### DIFF
--- a/snapshot/README.md
+++ b/snapshot/README.md
@@ -1,0 +1,26 @@
+# snapshot
+snapshot shows how you can convert incoming video frames to jpeg and serve them via HTTP.
+
+## Instructions
+
+### Download snapshow
+This example requires you to clone the repo since it is serving static HTML.
+
+```
+mkdir -p $GOPATH/src/github.com/pion
+cd $GOPATH/src/github.com/pion
+git clone https://github.com/pion/example-webrtc-applications.git
+cd example-webrtc-applications/snapshot
+```
+
+### Run snapshot
+Execute `go run *.go`
+
+### Open the Web UI
+Open [http://localhost:8080](http://localhost:8080) to publish your video and generate snapshots. You can open this page twice to generate snapshots and publish from different tabs, or you can do it in the same tab.
+
+First press `Publish Video` to start pushing video to your the Pion WebRTC backend. When you are ready to generate a snapshot press `Generate Snapshot`
+
+You can access the snapshot generator directly at [http://localhost:8080/snapshot](http://localhost:8080/snapshot)
+
+Congrats, you have used Pion WebRTC! Now start building something cool

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -1,0 +1,63 @@
+<html>
+  <head>
+    <title>snapshot</title>
+  </head>
+
+  <body>
+    <button onclick="window.publishVideo()"> Publish Video </button>
+    <button onclick="window.generateSnapshot()"> Generate Snapshot </button>
+    <br />
+
+    <h3> Snapshot </h3>
+    <img id="snapshot"> </div> <br />
+
+    <h3> Video Stream </h3>
+    <video id="localVideo" autoplay="true" controls="true"></video> <br />
+
+    <h3> Logs </h3>
+    <div id="logs"></div>
+  </body>
+
+  <script>
+    var log = msg => {
+      document.getElementById('logs').innerHTML += msg + '<br>'
+    }
+
+    window.publishVideo = () => {
+      let pc = new RTCPeerConnection()
+      navigator.mediaDevices.getUserMedia({video: true})
+        .then(stream => {
+          document.getElementById('localVideo').srcObject = stream
+          stream.getTracks().forEach(function(track) {
+            pc.addTrack(track, stream)
+          })
+
+          pc.createOffer()
+            .then(offer => {
+              pc.setLocalDescription(offer)
+
+              return fetch(`/signal`, {
+                method: 'post',
+                headers: {
+                  'Accept': 'application/json, text/plain, */*',
+                  'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(offer)
+              })
+            })
+            .then(res => res.json())
+            .then(res => pc.setRemoteDescription(res))
+            .catch(log)
+        }).catch(log)
+    }
+
+    window.generateSnapshot = () => {
+      fetch(`/snapshot`)
+        .then(response => response.blob())
+        .then(image => {
+          document.getElementById('snapshot').src = URL.createObjectURL(image)
+        })
+    }
+
+  </script>
+</html>

--- a/snapshot/main.go
+++ b/snapshot/main.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"image/jpeg"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/pion/rtcp"
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
+	"github.com/pion/webrtc/v2"
+	"github.com/pion/webrtc/v2/pkg/media/samplebuilder"
+	"golang.org/x/image/vp8"
+)
+
+// Channel for PeerConnection to push RTP Packets
+// This is the read from HTTP Handler for generating jpeg
+var rtpChan chan *rtp.Packet // nolint:gochecknoglobals
+
+func signaling(w http.ResponseWriter, r *http.Request) {
+	// Create a new PeerConnection
+	peerConnection, err := webrtc.NewPeerConnection(webrtc.Configuration{
+		ICEServers: []webrtc.ICEServer{
+			{
+				URLs: []string{"stun:stun.l.google.com:19302"},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Set a handler for when a new remote track starts, this handler saves buffers to SampleBuilder
+	// so we can generate a snapshot
+	peerConnection.OnTrack(func(track *webrtc.Track, receiver *webrtc.RTPReceiver) {
+		// Send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
+		go func() {
+			ticker := time.NewTicker(time.Second * 3)
+			for range ticker.C {
+				errSend := peerConnection.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: track.SSRC()}})
+				if errSend != nil {
+					fmt.Println(errSend)
+				}
+			}
+		}()
+
+		for {
+			// Read RTP Packets in a loop
+			rtpPacket, readErr := track.ReadRTP()
+			if readErr != nil {
+				panic(readErr)
+			}
+
+			// Use a lossy channel to send packets to snapshot handler
+			// We don't want to block and queue up old data
+			select {
+			case rtpChan <- rtpPacket:
+			default:
+			}
+		}
+	})
+
+	// Set the handler for ICE connection state
+	// This will notify you when the peer has connected/disconnected
+	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
+		fmt.Printf("ICE Connection State has changed: %s\n", connectionState.String())
+	})
+
+	var offer webrtc.SessionDescription
+	if err = json.NewDecoder(r.Body).Decode(&offer); err != nil {
+		panic(err)
+	}
+
+	if err = peerConnection.SetRemoteDescription(offer); err != nil {
+		panic(err)
+	}
+
+	answer, err := peerConnection.CreateAnswer(nil)
+	if err != nil {
+		panic(err)
+	} else if err = peerConnection.SetLocalDescription(answer); err != nil {
+		panic(err)
+	}
+
+	response, err := json.Marshal(*peerConnection.LocalDescription())
+	if err != nil {
+		panic(err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(response); err != nil {
+		panic(err)
+	}
+}
+
+func snapshot(w http.ResponseWriter, r *http.Request) {
+	// Initialized with 20 maxLate, my samples sometimes 10-15 packets
+	sampleBuilder := samplebuilder.New(20, &codecs.VP8Packet{})
+	decoder := vp8.NewDecoder()
+
+	for {
+		// Pull RTP Packet from rtpChan
+		sampleBuilder.Push(<-rtpChan)
+
+		// Use SampleBuilder to generate full picture from many RTP Packets
+		sample := sampleBuilder.Pop()
+		if sample == nil {
+			continue
+		}
+
+		// Read VP8 header.
+		videoKeyframe := (sample.Data[0]&0x1 == 0)
+		if !videoKeyframe {
+			continue
+		}
+
+		// Begin VP8-to-image decode: Init->DecodeFrameHeader->DecodeFrame
+		decoder.Init(bytes.NewReader(sample.Data), len(sample.Data))
+
+		// Decode header
+		if _, err := decoder.DecodeFrameHeader(); err != nil {
+			panic(err)
+		}
+
+		// Decode Frame
+		img, err := decoder.DecodeFrame()
+		if err != nil {
+			panic(err)
+		}
+
+		// Encode to (RGB) jpeg
+		buffer := new(bytes.Buffer)
+		if err = jpeg.Encode(buffer, img, nil); err != nil {
+			panic(err)
+		}
+
+		// Serve image
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Header().Set("Content-Length", strconv.Itoa(len(buffer.Bytes())))
+
+		// Write jpeg as HTTP Response
+		if _, err = w.Write(buffer.Bytes()); err != nil {
+			panic(err)
+		}
+		return
+	}
+}
+
+func main() {
+	rtpChan = make(chan *rtp.Packet)
+
+	http.Handle("/", http.FileServer(http.Dir(".")))
+	http.HandleFunc("/signal", signaling)
+	http.HandleFunc("/snapshot", snapshot)
+
+	fmt.Println("Open http://localhost:8080 to access this demo")
+	panic(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
Demonstrates how you can generate a jpeg from an incoming WebRTC
feed.

Relates to pion/webrtc#1354

Co-authored-by: mholbergerNIMBL