### PR TITLE
Fix race condition bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Tristan Matthews](https://github.com/tmatth)
 * [Alexey Kravtsov](https://github.com/alexey-kravtsov) - *GStreamer encoder tune*
 * [Tarrence van As](https://github.com/tarrencev) - *Webm saver fix*
+* [Cameron Elliott](https://github.com/cameronelliott) - *Small race bug fix*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/sfu-ws/room.go
+++ b/sfu-ws/room.go
@@ -63,8 +63,7 @@ func room(w http.ResponseWriter, r *http.Request) {
 	mt, msg, err := c.ReadMessage()
 	checkError(err)
 
-	if atomic.LoadInt32(&pubCount) == 0 {
-		atomic.AddInt32(&pubCount, 1)
+	if atomic.AddInt32(&pubCount, 1) == 1 {		
 
 		// Create a new RTCPeerConnection
 		pubReceiver, err = api.NewPeerConnection(peerConnectionConfig)


### PR DESCRIPTION
#### Description
I have thought about fixing this a half dozen times, and decided to be shy, and not bother the busy Pion team, but it is bugging me, so here it is.
Besides, this is a nice gentle entry into committing against Pion. :smile: 

The original code.
```
	if atomic.LoadInt32(&pubCount) == 0 {
		atomic.AddInt32(&pubCount, 1)
```
I believe the intent is to only allow a single publisher to be created. Which is what will usually occur, but under the right [very rare] conditions, this can be violated, so while this is a low-probability race condition, it is possible.
To achieve what I think was intended, we need:
```
	if atomic.AddInt32(&pubCount, 1) == 1 {		
```



#### Reference issue
No issue filed. Just PR to fix tiny 
