### PR TITLE
Found a JS Error when running the example JS fiddle code in safari.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Tristan Matthews](https://github.com/tmatth)
 * [Alexey Kravtsov](https://github.com/alexey-kravtsov) - *GStreamer encoder tune*
 * [Tarrence van As](https://github.com/tarrencev) - *Webm saver fix*
+* [Jamie Good](https://github.com/jamiegood) - *Bug fix in jsfiddle example*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/gstreamer-receive/README.md
+++ b/gstreamer-receive/README.md
@@ -17,7 +17,7 @@ go get github.com/pion/example-webrtc-applications/gstreamer-receive
 ```
 
 ### Open gstreamer-receive example page
-[jsfiddle.net](https://jsfiddle.net/8t2g5Lar/) you should see your Webcam, two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/cqavdpj8/1/) you should see your Webcam, two text-areas and a 'Start Session' button
 
 ### Run gstreamer-receive with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/gstreamer-receive/jsfiddle/demo.js
+++ b/gstreamer-receive/jsfiddle/demo.js
@@ -24,7 +24,12 @@ let displayVideo = video => {
 
 navigator.mediaDevices.getUserMedia({ video: true, audio: true })
   .then(stream => {
-    pc.addStream(displayVideo(stream))
+  
+    stream.getTracks().forEach(function(track) {
+      pc.addTrack(track, stream);
+    });
+
+    displayVideo(stream)
     pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
   }).catch(log)
 
@@ -51,7 +56,11 @@ window.startSession = () => {
 window.addDisplayCapture = () => {
   navigator.mediaDevices.getDisplayMedia().then(stream => {
     document.getElementById('displayCapture').disabled = true
-    pc.addStream(displayVideo(stream))
+    
+    stream.getTracks().forEach(function(track) {
+     pc.addTrack(track, displayVideo(stream));
+    });
+  
     pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
   })
 }


### PR DESCRIPTION
Error from Logs: TypeError: pc.addStream is not a function. (In 'pc.addStream(displayVideo(stream))', 'pc.addStream' is undefined)

Fixed js error when using Safari due to use of deprecated RTCPeerConnection.addStream() method.

Updated js fiddle example to use the  addTrack() method instead.
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream

#### Description

#### Reference issue
Fixes #...
