### PR TITLE
Draft: added example code for nack, and jitter buffer

### DIFF
--- a/utils/jitter_buffer.go
+++ b/utils/jitter_buffer.go
@@ -1,0 +1,89 @@
+package utils
+
+import (
+	"github.com/pion/rtp"
+)
+
+type JitterBuffer struct {
+	nextStart int64
+	end       int64
+	packets   []*rtp.Packet
+	size      int64
+}
+
+func NewJitterBuffer(size int) *JitterBuffer {
+	return &JitterBuffer{
+		packets: make([]*rtp.Packet, size),
+		size:    int64(size),
+	}
+}
+
+func (s *JitterBuffer) Add(seq int64, packet *rtp.Packet) bool {
+	if s.end-seq >= s.size {
+		return false
+	}
+
+	if seq <= s.end && s.packets[seq%s.size] != nil {
+		return false
+	}
+
+	if s.nextStart == 0 {
+		s.nextStart = seq
+	}
+
+	if seq > s.end {
+		if seq-s.end >= s.size {
+			s.packets = make([]*rtp.Packet, s.size)
+		} else {
+			for i := s.end + 1; i < seq; i++ {
+				s.packets[i%s.size] = nil
+			}
+		}
+		s.end = seq
+	}
+
+	if s.nextStart < s.end-s.size+1 {
+		s.nextStart = s.end - s.size + 1
+	}
+
+	s.packets[seq%s.size] = packet
+
+	return true
+}
+
+func (s *JitterBuffer) NextPackets() []*rtp.Packet {
+	if s.nextStart > s.end {
+		return nil
+	}
+
+	if s.packets[s.nextStart%s.size] == nil {
+		return nil
+	}
+
+	end := s.end // return until sequence end unless a there is a missing packet
+	for i := s.nextStart + 1; i <= s.end; i++ {
+		if s.packets[i%s.size] == nil {
+			end = i - 1 // missing packet found, return until previous packet
+			break
+		}
+	}
+
+	packets := make([]*rtp.Packet, 0, end-s.nextStart+1)
+	for i := s.nextStart; i <= end; i++ {
+		packets = append(packets, s.packets[i%s.size])
+		s.packets[i%s.size] = nil
+	}
+
+	s.nextStart = end + 1
+
+	return packets
+}
+
+func (s *JitterBuffer) SetNextPacketsStart(nextPacketsStart int64) {
+	if s.nextStart < nextPacketsStart {
+		for i := s.nextStart; i < nextPacketsStart; i++ {
+			s.packets[i%s.size] = nil
+		}
+		s.nextStart = nextPacketsStart
+	}
+}

--- a/utils/jitter_buffer_test.go
+++ b/utils/jitter_buffer_test.go
@@ -1,0 +1,115 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pion/rtp"
+)
+
+type testAdd struct {
+	seq       int64
+	payload   string
+	wantAdded bool
+}
+
+type testBuffer struct {
+	wantNextStart int64
+	wantEnd       int64
+	wantPayload   string
+}
+
+func TestJitterBuffer(t *testing.T) {
+	b := NewJitterBuffer(8)
+
+	wantAdd(t, b, testAdd{seq: 100, payload: "0", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 100, wantEnd: 100, wantPayload: "-,-,-,-,0,-,-,-"})
+	wantAdd(t, b, testAdd{seq: 101, payload: "1", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 100, wantEnd: 101, wantPayload: "-,-,-,-,0,1,-,-"})
+	wantAdd(t, b, testAdd{seq: 103, payload: "3", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 100, wantEnd: 103, wantPayload: "-,-,-,-,0,1,-,3"})
+	wantAdd(t, b, testAdd{seq: 104, payload: "4", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 100, wantEnd: 104, wantPayload: "4,-,-,-,0,1,-,3"})
+	wantAdd(t, b, testAdd{seq: 106, payload: "6", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 100, wantEnd: 106, wantPayload: "4,-,6,-,0,1,-,3"})
+	wantAdd(t, b, testAdd{seq: 105, payload: "5", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 100, wantEnd: 106, wantPayload: "4,5,6,-,0,1,-,3"})
+	wantAdd(t, b, testAdd{seq: 107, payload: "7", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 100, wantEnd: 107, wantPayload: "4,5,6,7,0,1,-,3"})
+
+	wantNextPackets(t, b, "0,1")
+	wantBuffer(t, b, testBuffer{wantNextStart: 102, wantEnd: 107, wantPayload: "4,5,6,7,-,-,-,3"})
+	wantNextPackets(t, b, "")
+
+	wantAdd(t, b, testAdd{seq: 108, payload: "8", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 102, wantEnd: 108, wantPayload: "4,5,6,7,8,-,-,3"})
+	wantAdd(t, b, testAdd{seq: 109, payload: "9", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 102, wantEnd: 109, wantPayload: "4,5,6,7,8,9,-,3"})
+	wantAdd(t, b, testAdd{seq: 110, payload: "a", wantAdded: true})
+	wantBuffer(t, b, testBuffer{wantNextStart: 103, wantEnd: 110, wantPayload: "4,5,6,7,8,9,a,3"})
+
+	wantNextPackets(t, b, "3,4,5,6,7,8,9,a")
+	wantBuffer(t, b, testBuffer{wantNextStart: 111, wantEnd: 110, wantPayload: "-,-,-,-,-,-,-,-"})
+	wantNextPackets(t, b, "")
+
+	wantAdd(t, b, testAdd{seq: 2, payload: "2", wantAdded: false})
+	wantBuffer(t, b, testBuffer{wantNextStart: 111, wantEnd: 110, wantPayload: "-,-,-,-,-,-,-,-"})
+}
+
+func wantNextPackets(t *testing.T, b *JitterBuffer, wantPayload string) {
+	t.Helper()
+	gotPayload := packetsPayload(b.NextPackets())
+	errors := make([]string, 0)
+	if wantPayload != gotPayload {
+		errors = append(errors, fmt.Sprintf("payload want/got: %s/%s", wantPayload, gotPayload))
+	}
+
+	if len(errors) > 0 {
+		t.Errorf("NextPackets %s", strings.Join(errors, " "))
+	}
+}
+
+func wantAdd(t *testing.T, b *JitterBuffer, add testAdd) {
+	t.Helper()
+	added := b.Add(add.seq, &rtp.Packet{
+		Payload: []byte(add.payload),
+	},
+	)
+	if add.wantAdded != added {
+		t.Errorf("Added (seq: %d, payload: %s) added want/got: %t/%t", add.seq, add.payload, add.wantAdded, added)
+	}
+}
+
+func wantBuffer(t *testing.T, b *JitterBuffer, buffer testBuffer) {
+	t.Helper()
+
+	errors := make([]string, 0)
+	if buffer.wantNextStart != b.nextStart {
+		errors = append(errors, fmt.Sprintf("nextStart want/got: %d/%d", buffer.wantNextStart, b.nextStart))
+	}
+	if buffer.wantEnd != b.end {
+		errors = append(errors, fmt.Sprintf("end want/got: %d/%d", buffer.wantEnd, b.end))
+	}
+	payload := packetsPayload(b.packets)
+	if buffer.wantPayload != payload {
+		errors = append(errors, fmt.Sprintf("payload want/got: %s/%s", buffer.wantPayload, payload))
+	}
+
+	if len(errors) > 0 {
+		t.Errorf("Buffer %s", strings.Join(errors, " "))
+	}
+}
+
+func packetsPayload(packets []*rtp.Packet) string {
+	results := make([]string, 0, len(packets))
+	for _, p := range packets {
+		if p == nil {
+			results = append(results, "-")
+		} else {
+			results = append(results, string(p.Payload))
+		}
+	}
+
+	return strings.Join(results, ",")
+}

--- a/utils/nack.go
+++ b/utils/nack.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"github.com/pion/rtcp"
+)
+
+func NackPairs(seqNums []uint16) []rtcp.NackPair {
+	pairs := make([]rtcp.NackPair, 0)
+	startSeq := seqNums[0]
+	nackPair := &rtcp.NackPair{PacketID: startSeq}
+	for i := 1; i < len(seqNums); i++ {
+		m := seqNums[i]
+
+		if m-nackPair.PacketID > 16 {
+			pairs = append(pairs, *nackPair)
+			nackPair = &rtcp.NackPair{PacketID: m}
+			continue
+		}
+
+		nackPair.LostPackets |= 1 << (m - nackPair.PacketID - 1)
+	}
+
+	pairs = append(pairs, *nackPair)
+
+	return pairs
+}
+
+func NackParsToSequenceNumbers(pairs []rtcp.NackPair) []uint16 {
+	seqs := make([]uint16, 0)
+	for _, pair := range pairs {
+		startSeq := pair.PacketID
+		seqs = append(seqs, startSeq)
+		for i := 0; i < 16; i++ {
+			if (pair.LostPackets & (1 << i)) != 0 {
+				seqs = append(seqs, startSeq+uint16(i)+1)
+			}
+		}
+	}
+
+	return seqs
+}

--- a/utils/nack_test.go
+++ b/utils/nack_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/kr/pretty"
+	"github.com/pion/rtcp"
+)
+
+func TestNackPairs(t *testing.T) {
+	u16 := func(i int) uint16 {
+		return uint16(i)
+	}
+
+	seqNums := []uint16{
+		65533, 65534, u16(65547), u16(65548), u16(65549),
+		u16(65550),
+		u16(65580), u16(65581),
+	}
+
+	wantPairs := []rtcp.NackPair{
+		{PacketID: 65533, LostPackets: 0b1110000000000001},
+		{PacketID: 14, LostPackets: 0b0000000000000000},
+		{PacketID: 44, LostPackets: 0b0000000000000001},
+	}
+
+	pairs := NackPairs(seqNums)
+
+	if diff := pretty.Diff(wantPairs, pairs); len(diff) > 0 {
+		t.Errorf("want/got: %v", diff)
+	}
+}
+
+func TestNackParsToSequenceNumbers(t *testing.T) {
+	pairs := []rtcp.NackPair{
+		{PacketID: 65533, LostPackets: 0b1110000000000001},
+		{PacketID: 14, LostPackets: 0b0000000000000000},
+		{PacketID: 44, LostPackets: 0b0000000000000001},
+	}
+
+	u16 := func(i int) uint16 {
+		return uint16(i)
+	}
+
+	wantSeqNums := []uint16{
+		65533, 65534, u16(65547), u16(65548), u16(65549),
+		u16(65550),
+		u16(65580), u16(65581),
+	}
+
+	seqNums := NackParsToSequenceNumbers(pairs)
+
+	if diff := pretty.Diff(wantSeqNums, seqNums); len(diff) > 0 {
+		t.Errorf("want/got: %v", diff)
+	}
+}

--- a/utils/receive_log.go
+++ b/utils/receive_log.go
@@ -1,0 +1,128 @@
+package utils
+
+import (
+	"errors"
+	"strconv"
+)
+
+var allowedReceiveLogSizes map[uint16]bool
+var invalidReceiveLogSizeError string
+
+func init() {
+	allowedReceiveLogSizes = make(map[uint16]bool, 15)
+	invalidReceiveLogSizeError = "invalid ReceiveLog size, must be one of: "
+	for i := 6; i < 16; i++ {
+		allowedReceiveLogSizes[1<<i] = true
+		invalidReceiveLogSizeError += strconv.Itoa(1<<i) + ", "
+	}
+	invalidReceiveLogSizeError = invalidReceiveLogSizeError[0 : len(invalidReceiveLogSizeError)-2]
+}
+
+type ReceiveLog struct {
+	packets         []uint64
+	size            uint16
+	end             uint16
+	started         bool
+	lastConsecutive uint16
+}
+
+func NewReceiveLog(size uint16) (*ReceiveLog, error) {
+	if !allowedReceiveLogSizes[size] {
+		return nil, errors.New(invalidReceiveLogSizeError)
+	}
+
+	return &ReceiveLog{
+		packets: make([]uint64, size/64),
+		size:    size,
+	}, nil
+}
+
+func (s *ReceiveLog) Add(seq uint16) {
+	if !s.started {
+		s.set(seq)
+		s.end = seq
+		s.started = true
+		s.lastConsecutive = seq
+		return
+	}
+
+	diff := seq - s.end
+	if diff == 0 {
+		return
+	} else if diff < uint16SizeHalf {
+		// this means a positive diff, in other words seq > end (with counting for rollovers)
+		for i := s.end + 1; i != seq; i++ {
+			// clear packets between end and seq (these may contain packets from a "size" ago)
+			s.del(i)
+		}
+		s.end = seq
+
+		if s.lastConsecutive+1 == seq {
+			s.lastConsecutive = seq
+		} else if seq-s.lastConsecutive > s.size {
+			s.lastConsecutive = seq - s.size
+			s.fixLastConsecutive() // there might be valid packets at the beginning of the buffer now
+		}
+	} else {
+		// negative diff, seq < end (with counting for rollovers)
+		if s.lastConsecutive+1 == seq {
+			s.lastConsecutive = seq
+			s.fixLastConsecutive() // there might be other valid packets after seq
+		}
+	}
+
+	s.set(seq)
+}
+
+func (s *ReceiveLog) Get(seq uint16) bool {
+	diff := s.end - seq
+	if diff >= uint16SizeHalf {
+		return false
+	}
+
+	if diff >= s.size {
+		return false
+	}
+
+	return s.get(seq)
+}
+
+func (s *ReceiveLog) MissingSeqNumbers(skipLastN uint16) []uint16 {
+	until := s.end - skipLastN
+	if until-s.lastConsecutive >= uint16SizeHalf {
+		// until < s.lastConsecutive (counting for rollover)
+		return nil
+	}
+
+	missingPacketSeqNums := make([]uint16, 0)
+	for i := s.lastConsecutive + 1; i != until+1; i++ {
+		if !s.get(i) {
+			missingPacketSeqNums = append(missingPacketSeqNums, i)
+		}
+	}
+
+	return missingPacketSeqNums
+}
+
+func (s *ReceiveLog) set(seq uint16) {
+	pos := seq % s.size
+	s.packets[pos/64] |= 1 << (pos % 64)
+}
+
+func (s *ReceiveLog) del(seq uint16) {
+	pos := seq % s.size
+	s.packets[pos/64] &^= 1 << (pos % 64)
+}
+
+func (s *ReceiveLog) get(seq uint16) bool {
+	pos := seq % s.size
+	return (s.packets[pos/64] & (1 << (pos % 64))) != 0
+}
+
+func (s *ReceiveLog) fixLastConsecutive() {
+	i := s.lastConsecutive + 1
+	for ; i != s.end+1 && s.get(i); i++ {
+		// find all consecutive packets
+	}
+	s.lastConsecutive = i - 1
+}

--- a/utils/receive_log_test.go
+++ b/utils/receive_log_test.go
@@ -1,0 +1,134 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestReceivedBuffer(t *testing.T) {
+	for _, start := range []uint16{0, 1, 127, 128, 129, 511, 512, 513, 32767, 32768, 32769, 65407, 65408, 65409, 65534, 65535} {
+		start := start
+
+		rl, err := NewReceiveLog(128)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		all := func(min uint16, max uint16) []uint16 {
+			result := make([]uint16, 0)
+			for i := min; i != max+1; i++ {
+				result = append(result, i)
+			}
+			return result
+		}
+		join := func(parts ...[]uint16) []uint16 {
+			result := make([]uint16, 0)
+			for _, p := range parts {
+				result = append(result, p...)
+			}
+			return result
+		}
+
+		add := func(nums ...uint16) {
+			for _, n := range nums {
+				seq := start + n
+				rl.Add(seq)
+			}
+		}
+
+		assertGet := func(nums ...uint16) {
+			t.Helper()
+			for _, n := range nums {
+				seq := start + n
+				if !rl.Get(seq) {
+					t.Errorf("not found: %d", seq)
+				}
+			}
+		}
+		assertNOTGet := func(nums ...uint16) {
+			t.Helper()
+			for _, n := range nums {
+				seq := start + n
+				if rl.Get(seq) {
+					t.Errorf("packet found for %d", seq)
+				}
+			}
+		}
+		assertMissing := func(skipLastN uint16, nums []uint16) {
+			t.Helper()
+			missing := rl.MissingSeqNumbers(skipLastN)
+			if missing == nil {
+				missing = []uint16{}
+			}
+			want := make([]uint16, 0, len(nums))
+			for _, n := range nums {
+				want = append(want, start+n)
+			}
+			if !reflect.DeepEqual(want, missing) {
+				t.Errorf("missing want/got %v / %v", want, missing)
+			}
+		}
+		assertLastConsecutive := func(lastConsecutive uint16) {
+			want := lastConsecutive + start
+			if rl.lastConsecutive != want {
+				t.Errorf("invalid lastConsecutive want %d got %d", want, rl.lastConsecutive)
+			}
+		}
+
+		add(0)
+		assertGet(0)
+		assertMissing(0, []uint16{})
+		assertLastConsecutive(0) // first element added
+
+		add(all(1, 127)...)
+		assertGet(all(1, 127)...)
+		assertMissing(0, []uint16{})
+		assertLastConsecutive(127)
+
+		add(128)
+		assertGet(128)
+		assertNOTGet(0)
+		assertMissing(0, []uint16{})
+		assertLastConsecutive(128)
+
+		add(130)
+		assertGet(130)
+		assertNOTGet(1, 2, 129)
+		assertMissing(0, []uint16{129})
+		assertLastConsecutive(128)
+
+		add(333)
+		assertGet(333)
+		assertNOTGet(all(0, 332)...)
+		assertMissing(0, all(206, 332))  // all 127 elements missing before 333
+		assertMissing(10, all(206, 323)) // skip last 10 packets (324-333) from check
+		assertLastConsecutive(205)       // lastConsecutive is still out of the buffer
+
+		add(329)
+		assertGet(329)
+		assertMissing(0, join(all(206, 328), all(330, 332)))
+		assertMissing(5, join(all(206, 328))) // skip last 5 packets (329-333) from check
+		assertLastConsecutive(205)
+
+		add(all(207, 320)...)
+		assertGet(all(207, 320)...)
+		assertMissing(0, join([]uint16{206}, all(321, 328), all(330, 332)))
+		assertLastConsecutive(205)
+
+		add(334)
+		assertGet(334)
+		assertNOTGet(206)
+		assertMissing(0, join(all(321, 328), all(330, 332)))
+		assertLastConsecutive(320) // head of buffer is full of consecutive packages
+
+		add(all(322, 328)...)
+		assertGet(all(322, 328)...)
+		assertMissing(0, join([]uint16{321}, all(330, 332)))
+		assertLastConsecutive(320)
+
+		add(321)
+		assertGet(321)
+		assertMissing(0, all(330, 332))
+		assertLastConsecutive(329) // after adding a single missing packet, lastConsecutive should jump forward
+	}
+}

--- a/utils/send_buffer.go
+++ b/utils/send_buffer.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/pion/rtp"
+)
+
+const (
+	uint16SizeHalf = 1 << 15
+)
+
+var allowedSendBufferSizes map[uint16]bool
+var invalidSendBufferSizeError string
+
+func init() {
+	allowedSendBufferSizes = make(map[uint16]bool, 15)
+	invalidSendBufferSizeError = "invalid sendBuffer size, must be one of: "
+	for i := 0; i < 16; i++ {
+		allowedSendBufferSizes[1<<i] = true
+		invalidSendBufferSizeError += strconv.Itoa(1<<i) + ", "
+	}
+	invalidSendBufferSizeError = invalidSendBufferSizeError[0 : len(invalidSendBufferSizeError)-2]
+}
+
+type SendBuffer struct {
+	packets   []*rtp.Packet
+	size      uint16
+	lastAdded uint16
+	started   bool
+}
+
+func NewSendBuffer(size uint16) (*SendBuffer, error) {
+	if !allowedSendBufferSizes[size] {
+		return nil, errors.New(invalidSendBufferSizeError)
+	}
+
+	return &SendBuffer{
+		packets: make([]*rtp.Packet, size),
+		size:    size,
+	}, nil
+}
+
+func (s *SendBuffer) Add(packet *rtp.Packet) {
+	seq := packet.SequenceNumber
+	if !s.started {
+		s.packets[seq%s.size] = packet
+		s.lastAdded = seq
+		s.started = true
+		return
+	}
+
+	diff := seq - s.lastAdded
+	if diff == 0 {
+		return
+	} else if diff < uint16SizeHalf {
+		for i := s.lastAdded + 1; i != seq; i++ {
+			s.packets[i%s.size] = nil
+		}
+	}
+
+	s.packets[seq%s.size] = packet
+	s.lastAdded = seq
+}
+
+func (s *SendBuffer) Get(seq uint16) *rtp.Packet {
+	diff := s.lastAdded - seq
+	if diff >= uint16SizeHalf {
+		return nil
+	}
+
+	if diff >= s.size {
+		return nil
+	}
+
+	return s.packets[seq%s.size]
+}

--- a/utils/send_buffer_test.go
+++ b/utils/send_buffer_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/pion/rtp"
+)
+
+func TestSendBuffer(t *testing.T) {
+	for _, start := range []uint16{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 511, 512, 513, 32767, 32768, 32769, 65527, 65528, 65529, 65530, 65531, 65532, 65533, 65534, 65535} {
+		start := start
+
+		sb, err := NewSendBuffer(8)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		add := func(nums ...uint16) {
+			for _, n := range nums {
+				seq := start + n
+				sb.Add(&rtp.Packet{Header: rtp.Header{SequenceNumber: seq}})
+			}
+		}
+
+		assertGet := func(nums ...uint16) {
+			t.Helper()
+			for _, n := range nums {
+				seq := start + n
+				packet := sb.Get(seq)
+				if packet == nil {
+					t.Errorf("packet not found: %d", seq)
+					continue
+				}
+				if packet.SequenceNumber != seq {
+					t.Errorf("packet for %d returned with incorrect SequenceNumber: %d", seq, packet.SequenceNumber)
+				}
+			}
+		}
+		assertNOTGet := func(nums ...uint16) {
+			t.Helper()
+			for _, n := range nums {
+				seq := start + n
+				packet := sb.Get(seq)
+				if packet != nil {
+					t.Errorf("packet found for %d: %d", seq, packet.SequenceNumber)
+				}
+			}
+		}
+
+		add(0, 1, 2, 3, 4, 5, 6, 7)
+		assertGet(0, 1, 2, 3, 4, 5, 6, 7)
+
+		add(8)
+		assertGet(8)
+		assertNOTGet(0)
+
+		add(10)
+		assertGet(10)
+		assertNOTGet(1, 2, 9)
+
+		add(22)
+		assertGet(22)
+		assertNOTGet(3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
+	}
+}

--- a/utils/sequence_unwrapper.go
+++ b/utils/sequence_unwrapper.go
@@ -1,0 +1,64 @@
+package utils
+
+import "sync"
+
+type SequenceUnwrapper struct {
+	m                     *sync.Mutex
+	wrapArounds           int64
+	highestSequenceNumber uint64
+	inMax                 uint64
+	started               bool
+}
+
+func NewSequenceUnwrapper(base int) *SequenceUnwrapper {
+	return &SequenceUnwrapper{
+		m:     &sync.Mutex{},
+		inMax: 1 << uint64(base),
+	}
+}
+
+// Unwrap accepts a uint<base> values which form a sequence, and converts the values into
+// int64 while adjusting the sequence every time a wraparound happens. For example:
+// unwrapper := NewSequenceUnwrapper(16)
+// ...
+// unwrapper.Unwrap(65534) == 65534
+// unwrapper.Unwrap(65535) == 65535
+// unwrapper.Unwrap(0) == 65536
+// unwrapper.Unwrap(1) == 65537
+// ...
+// unwrapper.Unwrap(65534) == 131070
+// unwrapper.Unwrap(65535) == 131071
+// unwrapper.Unwrap(0) == 131072
+// unwrapper.Unwrap(1) == 131073
+// ...
+func (sw *SequenceUnwrapper) Unwrap(n uint64) int64 {
+	sw.m.Lock()
+	defer sw.m.Unlock()
+
+	if !sw.started {
+		sw.started = true
+		sw.highestSequenceNumber = n
+		return int64(n)
+	}
+
+	if n == sw.highestSequenceNumber {
+		return sw.wrapArounds + int64(n)
+	}
+
+	if n < sw.highestSequenceNumber {
+		if sw.highestSequenceNumber-n > sw.inMax/2 {
+			sw.wrapArounds += int64(sw.inMax)
+			sw.highestSequenceNumber = n
+			return sw.wrapArounds + int64(n)
+		}
+
+		return sw.wrapArounds + int64(n)
+	}
+
+	if n-sw.highestSequenceNumber > sw.inMax/2 {
+		return sw.wrapArounds - int64(sw.inMax) + int64(n)
+	}
+
+	sw.highestSequenceNumber = n
+	return sw.wrapArounds + int64(n)
+}

--- a/utils/sequence_unwrapper_test.go
+++ b/utils/sequence_unwrapper_test.go
@@ -1,0 +1,149 @@
+package utils
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestSequenceUnwrapper(t *testing.T) {
+	for _, data := range []struct {
+		baseIn      int
+		min         int64
+		max         int64
+		cutOverflow func(int64) uint64
+	}{
+		{
+			baseIn:      16,
+			min:         0,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         1,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         2,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         32765,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         32766,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         32767,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         32768,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         32769,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         32770,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         32771,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         65529,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         65530,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      16,
+			min:         65531,
+			max:         131100,
+			cutOverflow: func(i int64) uint64 { return uint64(uint16(i)) },
+		},
+		{
+			baseIn:      32,
+			min:         4294967290,
+			max:         4294967310,
+			cutOverflow: func(i int64) uint64 { return uint64(uint32(i)) },
+		},
+		{
+			baseIn:      32,
+			min:         4294967291,
+			max:         4294967310,
+			cutOverflow: func(i int64) uint64 { return uint64(uint32(i)) },
+		},
+		{
+			baseIn:      32,
+			min:         4294967292,
+			max:         4294967310,
+			cutOverflow: func(i int64) uint64 { return uint64(uint32(i)) },
+		},
+	} {
+		data := data
+		t.Run(fmt.Sprintf("%d-%d", data.min, data.max), func(t *testing.T) {
+			seqNorm := NewSequenceUnwrapper(data.baseIn)
+			for want := data.min; want < data.max; {
+				got := seqNorm.Unwrap(data.cutOverflow(want))
+				if want != got {
+					t.Fatalf("step: -1, want: %d, got: %d", want, got)
+				}
+
+				want += 3
+				got = seqNorm.Unwrap(data.cutOverflow(want))
+				if want != got {
+					t.Fatalf("step: +3, want: %d, got: %d", want, got)
+				}
+
+				want--
+			}
+		})
+	}
+}
+
+func TestSequenceUnwrapperBackConvert(t *testing.T) {
+	seqNorm := NewSequenceUnwrapper(16)
+	for i := 0; i < 3; i++ {
+		for ui := uint16(0); ; ui++ {
+			unwrapped := seqNorm.Unwrap(uint64(ui))
+
+			if ui != uint16(unwrapped) {
+				t.Fatalf("%d != %d (%d)", ui, uint16(unwrapped), unwrapped)
+			}
+
+			if ui == math.MaxUint16 {
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
Related issue: https://github.com/pion/webrtc-v3-design/issues/36

This is just a showcase for nack, jitter buffer and sequence unwrapper usage.

## Sequence unwrapper
Converts the uint16 sequence number to int64 continous sequences (handles rollover). 

## Jitter buffer
This buffer currently requires an unwrapped sequence number. It can be modified to work like other buffers. Methods:

How it works: there is a fix sized slice behind it. The position of a packet in the buffer is calculated using `sequence_number modulo buffer_size` This way we can avoid shifting the buffer with every Add operation. For more details see test.

Methods:
- Add: adds a packet, return false if the packet is too old, or the packet has been added already.
- NextPackets: returns all the continous packets from the buffer head (the last packet+1 returned in previous call to NextPackets)
- SetNextPacketsStart: this can be used to skip packets in the buffer, useful when a keyframe arrives and we don't want to wait unnecceserly for earlier packets.

## SendBuffer
This buffer stores all sent packets. Similarly to jitter buffer, it uses `sequence_number modulo buffer_size` to determine the position of a packet in the buffer. The main difference is that this buffer supports uint16 sequence numbers with rollover. In exchange, there is a restriction in size, as `65536 modulo size == 0` must be true. This is needed so that when a rollover happens in sequence numbers, the rollover overlaps with the buffer rollover (eg: 65535 corresponds to the last element of the buffer). Can be modified to use unwrapped sequence number and remove the restriction to size.

## ReceiveLog
Similar to send buffer, but stores booleans as uint64 mask.

Methods:
- Add, Get: self explanatory
- MissingSeqNumbers: returns all missing elements of the log, except for any element in the last N packets of the buffer
