### PR TITLE
Found JS Error in gocv-reveivwhen running the example JS fiddle code in safari.

### DIFF
--- a/gocv-receive/README.md
+++ b/gocv-receive/README.md
@@ -18,7 +18,7 @@ go get github.com/pion/example-webrtc-applications/gocv-receive
 ```
 
 ### Open gocv-receive example page
-[jsfiddle.net](https://jsfiddle.net/b3d72av1/) you should see your Webcam, two text-areas and a 'Start Session' button
+[jsfiddle.net](https://jsfiddle.net/ve9udLwb/) you should see your Webcam, two text-areas and a 'Start Session' button
 
 ### Run gocv-receive with your browsers SessionDescription as stdin
 In the jsfiddle the top textarea is your browser, copy that and:

--- a/gocv-receive/jsfiddle/demo.js
+++ b/gocv-receive/jsfiddle/demo.js
@@ -13,7 +13,13 @@ var log = msg => {
 
 navigator.mediaDevices.getUserMedia({ video: true, audio: true })
   .then(stream => {
-    pc.addStream(document.getElementById('video1').srcObject = stream)
+
+    document.getElementById('video1').srcObject = stream
+
+    stream.getTracks().forEach(function(track) {
+      pc.addTrack(track, stream);
+     });
+
     pc.createOffer().then(d => pc.setLocalDescription(d)).catch(log)
   }).catch(log)
 


### PR DESCRIPTION
Logs: TypeError: pc.addStream is not a function. (In 'pc.addStream(displayVideo(stream))', 'pc.addStream' is undefined)
Fixed js error when using safari due to deprecated RTCPeerConnection.addStream() method.
Updated js fiddle example to use the  addTrack() method instead.
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream

