### PR TITLE
Lowercase code name

### DIFF
--- a/gstreamer-receive/main.go
+++ b/gstreamer-receive/main.go
@@ -49,7 +49,7 @@ func gstreamerReceiveMain() {
 
 		codecName := strings.Split(track.Codec().RTPCodecCapability.MimeType, "/")[1]
 		fmt.Printf("Track has started, of type %d: %s \n", track.PayloadType(), codecName)
-		pipeline := gst.CreatePipeline(codecName)
+		pipeline := gst.CreatePipeline(strings.ToLower(codecName))
 		pipeline.Start()
 		buf := make([]byte, 1400)
 		for {


### PR DESCRIPTION
#### Description
The code name may be uppercase,
it needs to be converted to lowercase when calling gst.CreatePipeline.
