### PR TITLE
Fix gocv-receive example

### DIFF
--- a/gocv-receive/README.md
+++ b/gocv-receive/README.md
@@ -11,6 +11,8 @@ This example requires you have GoCV and ffmpeg installed, these are the supporte
 #### Debian/Ubuntu
 * Follow the setup instructions for [GoCV](https://github.com/hybridgroup/gocv)
 * `sudo apt-get install ffmpeg`
+#### macOS
+* `brew install ffmpeg opencv`
 
 ### Build gocv-receive
 ```


### PR DESCRIPTION
Fix gocv-receive example

Error build: cannot range over contours (type gocv.PointsVector).

Error run on macOS: NSWindow drag regions should only be invalidated on the Main Thread.

