### PR TITLE
Avoid NullPointerException when addCandidate

### DIFF
--- a/sfu-ws/flutter/lib/main.dart
+++ b/sfu-ws/flutter/lib/main.dart
@@ -92,7 +92,7 @@ class _GetMyAppState extends State<MyApp> {
         case 'candidate':
           Map<String, dynamic> parsed = jsonDecode(msg['data']);
           _peerConnection
-              .addCandidate(RTCIceCandidate(parsed['candidate'], null, 0));
+              .addCandidate(RTCIceCandidate(parsed['candidate'], '', 0));
           return;
         case 'offer':
           Map<String, dynamic> offer = jsonDecode(msg['data']);


### PR DESCRIPTION
Set sdpMid value to an empty string replacing null for avoiding NullPointerException:

W/System.err(10024): java.lang.NullPointerException: Attempt to invoke virtual method 'byte[] java.lang.String.getBytes(java.lang.String)' on a null object reference
W/System.err(10024): 	at org.webrtc.JniHelper.getStringBytes(JniHelper.java:25)
W/System.err(10024): 	at org.webrtc.PeerConnection.nativeAddIceCandidate(Native Method)
W/System.err(10024): 	at org.webrtc.PeerConnection.addIceCandidate(PeerConnection.java:896)
W/System.err(10024): 	at com.cloudwebrtc.webrtc.MethodCallHandlerImpl.peerConnectionAddICECandidate(MethodCallHandlerImpl.java:1432)
W/System.err(10024): 	at com.cloudwebrtc.webrtc.MethodCallHandlerImpl.onMethodCall(MethodCallHandlerImpl.java:290)
W/System.err(10024): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:233)
W/System.err(10024): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:85)
W/System.err(10024): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:818)
W/System.err(10024): 	at android.os.MessageQueue.nativePollOnce(Native Method)
W/System.err(10024): 	at android.os.MessageQueue.next(MessageQueue.java:325)
W/System.err(10024): 	at android.os.Looper.loop(Looper.java:142)
W/System.err(10024): 	at android.app.ActivityThread.main(ActivityThread.java:6574)
W/System.err(10024): 	at java.lang.reflect.Method.invoke(Native Method)
W/System.err(10024): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:440)
W/System.err(10024): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
E/rtc     (10024): 
E/rtc     (10024): 
E/rtc     (10024): #
E/rtc     (10024): # Fatal error in: gen/sdk/android/generated_metrics_jni/../../../../../../../../usr/local/google/home/sakal/code/webrtc-aar-release/src/sdk/android/src/jni/jni_generator_helper.h, line 94
E/rtc     (10024): # last system error: 0
E/rtc     (10024): # Check failed: !env->ExceptionCheck()
E/rtc     (10024): # 
F/libc    (10024): Fatal signal 6 (SIGABRT), code -6 in tid 10024 (ple.flutter_prj), pid 10024 (ple.flutter_prj)

#### Description

#### Reference issue
Fixes #...
