### PR TITLE
added payloadType parameter to CreatePipeline

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,6 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Update packages
+        run: sudo apt-get update
+
       - name: Install GStreamer
         run: sudo apt-get install libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Jin Gong](https://github.com/cgojin)
 * [harkirat singh](https://github.com/hkirat)
 * [oasangqi](https://github.com/oasangqi)
+* [Shahin Sabooni](https://github.com/longlonghands)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/gstreamer-receive/main.go
+++ b/gstreamer-receive/main.go
@@ -49,7 +49,7 @@ func gstreamerReceiveMain() {
 
 		codecName := strings.Split(track.Codec().RTPCodecCapability.MimeType, "/")[1]
 		fmt.Printf("Track has started, of type %d: %s \n", track.PayloadType(), codecName)
-		pipeline := gst.CreatePipeline(strings.ToLower(codecName))
+		pipeline := gst.CreatePipeline(track.PayloadType(), strings.ToLower(codecName))
 		pipeline.Start()
 		buf := make([]byte, 1400)
 		for {

--- a/internal/gstreamer-sink/gst.go
+++ b/internal/gstreamer-sink/gst.go
@@ -9,8 +9,11 @@ package gst
 */
 import "C"
 import (
+	"fmt"
 	"strings"
 	"unsafe"
+
+	"github.com/pion/webrtc/v3"
 )
 
 // StartMainLoop starts GLib's main loop
@@ -27,13 +30,13 @@ type Pipeline struct {
 }
 
 // CreatePipeline creates a GStreamer Pipeline
-func CreatePipeline(codecName string) *Pipeline {
+func CreatePipeline(payloadType webrtc.PayloadType, codecName string) *Pipeline {
 	pipelineStr := "appsrc format=time is-live=true do-timestamp=true name=src ! application/x-rtp"
 	switch strings.ToLower(codecName) {
 	case "vp8":
-		pipelineStr += ", encoding-name=VP8-DRAFT-IETF-01 ! rtpvp8depay ! decodebin ! autovideosink"
+		pipelineStr += fmt.Sprintf(", payload=%d, encoding-name=VP8-DRAFT-IETF-01 ! rtpvp8depay ! decodebin ! autovideosink", payloadType)
 	case "opus":
-		pipelineStr += ", payload=96, encoding-name=OPUS ! rtpopusdepay ! decodebin ! autoaudiosink"
+		pipelineStr += fmt.Sprintf(", payload=%d, encoding-name=OPUS ! rtpopusdepay ! decodebin ! autoaudiosink", payloadType)
 	case "vp9":
 		pipelineStr += " ! rtpvp9depay ! decodebin ! autovideosink"
 	case "h264":


### PR DESCRIPTION
#### Description
When I tried to run `gstreamer-receive` example, Gstreamer pipeline couldn't start the stream. so I checked out the generated sdp from my browser (chrome) and I saw the Payload Type for codecs are not matching with the one provided for gstreamer pipeline.
In order to know the payload type for the pipeline, it's better to get it from the SDP. So I added payload type as a parameter to CreatePipeline function in gstreamer-sink and injected it using `track.PayloadType()`

#### Reference issue
