### PR TITLE
Fix golangci-lint URL

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,7 +48,7 @@ jobs:
         run:  cd c-data-channels && make
 
       - name: Install golangci-lint
-        run:  curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /tmp v1.19.1
+        run:  curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b /tmp v1.19.1
 
       - name: Run golangci-lint
         run:  go list -f '{{.Dir}}' ./... | fgrep -v c-data-channels | xargs realpath --relative-to=. | xargs /tmp/golangci-lint run -v


### PR DESCRIPTION
The old URL seems to point to nothing and is breaking PR CI checks like https://github.com/pion/example-webrtc-applications/runs/7727364808?check_suite_focus=true

It may be preferable to use their own GitHub Action instead, see:
- https://golangci-lint.run/usage/install/#ci-installation
- https://github.com/golangci/golangci-lint-action