### PR TITLE
Fix transceiver initialization for janus streaming

### DIFF
--- a/janus-gateway/streaming/main.go
+++ b/janus-gateway/streaming/main.go
@@ -110,9 +110,11 @@ func main() {
 		}
 
 		// We must offer to send media for Janus to send anything
-		if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeAudio); err != nil {
+		if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeAudio, webrtc.RTPTransceiverInit{
+			Direction: webrtc.RTPTransceiverDirectionRecvonly}); err != nil {
 			panic(err)
-		} else if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeVideo); err != nil {
+		} else if _, err = peerConnection.AddTransceiverFromKind(webrtc.RTPCodecTypeVideo, webrtc.RTPTransceiverInit{
+			Direction: webrtc.RTPTransceiverDirectionRecvonly}); err != nil {
 			panic(err)
 		}
 


### PR DESCRIPTION
#### Description
peerConnection.OnTrack was never being invoked if using the defaults,
recvonly must be explicitly set.

#### Reference issue
Fixes #120
