### PR TITLE
feat: adding install for newer versions of golang

### DIFF
--- a/gstreamer-receive/README.md
+++ b/gstreamer-receive/README.md
@@ -14,7 +14,7 @@ This example requires you have GStreamer installed, these are the supported plat
 ### Download gstreamer-receive
 ```
 export GO111MODULE=on
-go get github.com/pion/example-webrtc-applications/v3/gstreamer-receive
+go install github.com/pion/example-webrtc-applications/v3/gstreamer-receive@latest
 ```
 
 ### Open gstreamer-receive example page

--- a/gstreamer-send/README.md
+++ b/gstreamer-send/README.md
@@ -14,7 +14,7 @@ This example requires you have GStreamer installed, these are the supported plat
 ### Download gstreamer-send
 ```
 export GO111MODULE=on
-go get github.com/pion/example-webrtc-applications/v3/gstreamer-send
+go install github.com/pion/example-webrtc-applications/v3/gstreamer-send@latest
 ```
 
 ### Open gstreamer-send example page

--- a/play-from-disk-h264/README.md
+++ b/play-from-disk-h264/README.md
@@ -13,7 +13,7 @@ ffmpeg -i $INPUT_FILE -c:a libopus -page_duration 20000 -vn output.ogg
 ### Download play-from-disk-h264
 ```
 export GO111MODULE=on
-go get github.com/pion/example-webrtc-applications/v3/play-from-disk-h264
+go install github.com/pion/example-webrtc-applications/v3/play-from-disk-h264@latest
 ```
 
 ### Open play-from-disk-h264 example page

--- a/rtmp-to-webrtc/README.md
+++ b/rtmp-to-webrtc/README.md
@@ -9,7 +9,7 @@ of VP8 with H264 in `main.go`
 ### Download rtmp-to-webrtc
 ```
 export GO111MODULE=on
-go get github.com/pion/example-webrtc-applications/v3/rtmp-to-webrtc
+go install github.com/pion/example-webrtc-applications/v3/rtmp-to-webrtc@latest
 ```
 
 ### Open jsfiddle example page

--- a/twitch/README.md
+++ b/twitch/README.md
@@ -23,7 +23,7 @@ This example requires you have ffmpeg installed, these are the supported platfor
 ### Download twitch
 ```
 export GO111MODULE=on
-go get github.com/pion/example-webrtc-applications/v3/twitch
+go install github.com/pion/example-webrtc-applications/v3/twitch@latest
 ```
 
 ### Open twitch example page

--- a/unreal-pixel-streaming/README.md
+++ b/unreal-pixel-streaming/README.md
@@ -7,7 +7,7 @@ This example doesn't do anything with the media [rtp-forwarder](https://github.c
 ### Download unreal-pixel-streaming
 ```
 export GO111MODULE=on
-go get github.com/pion/example-webrtc-applications/v3/unreal-pixel-streaming
+go install github.com/pion/example-webrtc-applications/v3/unreal-pixel-streaming@latest
 ```
 
 ### Run unreal-pixel-streaming and pass the url and origin


### PR DESCRIPTION
#### Description

I just try out the examples this weekend and I run into the problem of go get the using a docker container with go version 1.22.2
even with the export module on go get was not possible I run this command `go install` and the examples still worked

#### Reference issue
Fixes #...

Only on docs